### PR TITLE
Add production years paragraph to history page

### DIFF
--- a/src/content/docs/overview/history.mdx
+++ b/src/content/docs/overview/history.mdx
@@ -7,7 +7,9 @@ sidebar:
 
 # E46 History
 
-The BMW E46 is the fourth generation of the BMW 3 Series, produced from 1997 to 2006. It succeeded the E36 and was eventually replaced by the E90.
+The BMW E46 3 Series was produced from 1997 to 2006. Sedan and Touring (wagon) production ran from 1997 to 2005, while the Coupé, Convertible, and M3 variants continued through 2006. In total, the E46 generation spanned nearly a decade on the production line — one of the longest and most successful runs for any 3 Series.
+
+The BMW E46 is the fourth generation of the BMW 3 Series. It succeeded the E36 and was eventually replaced by the E90.
 
 ## Development Timeline
 


### PR DESCRIPTION
## Summary

Adds a new introductory paragraph to the E46 History page highlighting the production years:

- **Sedan & Touring**: 1997–2005
- **Coupé, Convertible & M3**: continued through 2006
- Nearly a decade on the production line

The existing intro paragraph is preserved but streamlined to avoid repeating the date range.

Closes #2