### PR TITLE
Add website footer with navigation and copyright

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig({
 		starlight({
 			title: 'E46 Vault',
 			description: 'The encyclopedic reference for the BMW E46 330Ci and 330i (1999-2006)',
+			components: {
+				Footer: './src/components/Footer.astro',
+			},
 			social: [
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/catatwo/e46vault' },
 			],

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,125 @@
+---
+// Custom footer for E46 Vault
+// Overrides Starlight's default Footer component
+import type { Props } from '@astrojs/starlight/props';
+const currentYear = 2026;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+
+<footer class="e46-footer">
+  <div class="e46-footer-inner">
+    <nav class="e46-footer-nav" aria-label="Footer navigation">
+      <div class="e46-footer-col">
+        <h3>Quick Reference</h3>
+        <ul>
+          <li><a href={`${base}/reference/torque-specs/`}>Torque Specs</a></li>
+          <li><a href={`${base}/reference/fluid-capacities/`}>Fluid Capacities</a></li>
+          <li><a href={`${base}/reference/fault-codes/`}>Fault Codes</a></li>
+          <li><a href={`${base}/reference/fuse-chart/`}>Fuse Chart</a></li>
+        </ul>
+      </div>
+      <div class="e46-footer-col">
+        <h3>Popular Guides</h3>
+        <ul>
+          <li><a href={`${base}/engine/cooling/overview/`}>Cooling System</a></li>
+          <li><a href={`${base}/engine/vanos/how-it-works/`}>VANOS System</a></li>
+          <li><a href={`${base}/problems/overview/`}>Common Problems</a></li>
+          <li><a href={`${base}/maintenance/overview/`}>Maintenance</a></li>
+        </ul>
+      </div>
+      <div class="e46-footer-col">
+        <h3>Resources</h3>
+        <ul>
+          <li><a href={`${base}/buying/overview/`}>Buying Guide</a></li>
+          <li><a href={`${base}/resources/forums/`}>Forums</a></li>
+          <li><a href={`${base}/resources/suppliers/`}>Suppliers</a></li>
+          <li><a href="https://github.com/catatwo/e46vault">GitHub</a></li>
+        </ul>
+      </div>
+    </nav>
+    <div class="e46-footer-bottom">
+      <p class="e46-footer-copyright">&copy; {currentYear} <a href="https://github.com/catatwo">catatwo</a>. All rights reserved.</p>
+      <p class="e46-footer-disclaimer">E46 Vault is a community reference. Not affiliated with BMW AG.</p>
+    </div>
+  </div>
+</footer>
+
+<style>
+  .e46-footer {
+    border-top: 2px solid var(--bmw-blue, #0066b1);
+    background: color-mix(in srgb, var(--sl-color-bg, #fff) 97%, var(--bmw-blue, #0066b1));
+    padding: 2.5rem 1.5rem 1.5rem;
+    margin-top: 3rem;
+  }
+
+  .e46-footer-inner {
+    max-width: 72rem;
+    margin: 0 auto;
+  }
+
+  .e46-footer-nav {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .e46-footer-col h3 {
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--bmw-blue, #0066b1);
+    margin: 0 0 0.75rem;
+  }
+
+  .e46-footer-col ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .e46-footer-col li {
+    margin-bottom: 0.4rem;
+  }
+
+  .e46-footer-col a {
+    color: var(--sl-color-text, inherit);
+    text-decoration: none;
+    font-size: 0.9rem;
+    opacity: 0.8;
+    transition: opacity 0.15s, color 0.15s;
+  }
+
+  .e46-footer-col a:hover {
+    opacity: 1;
+    color: var(--bmw-blue, #0066b1);
+  }
+
+  .e46-footer-bottom {
+    border-top: 1px solid color-mix(in srgb, var(--sl-color-text, #000) 12%, transparent);
+    padding-top: 1.25rem;
+    text-align: center;
+  }
+
+  .e46-footer-copyright {
+    font-size: 0.88rem;
+    font-weight: 600;
+    margin: 0 0 0.35rem;
+  }
+
+  .e46-footer-copyright a {
+    color: var(--bmw-blue, #0066b1);
+    text-decoration: none;
+  }
+
+  .e46-footer-copyright a:hover {
+    text-decoration: underline;
+  }
+
+  .e46-footer-disclaimer {
+    font-size: 0.78rem;
+    opacity: 0.6;
+    margin: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds a custom site-wide footer to E46 Vault, replacing the default Starlight footer.

### What's included

- **Three navigation columns:**
  - **Quick Reference** — Torque Specs, Fluid Capacities, Fault Codes, Fuse Chart
  - **Popular Guides** — Cooling System, VANOS, Common Problems, Maintenance
  - **Resources** — Buying Guide, Forums, Suppliers, GitHub link
- **Copyright:** © 2026 catatwo (linked to GitHub profile)
- **Disclaimer:** "Not affiliated with BMW AG"
- **Styling:** BMW-themed, consistent with the existing design system (uses `--bmw-blue`, Starlight tokens). Responsive grid layout.

### Implementation

Overrides Starlight's `Footer` component via the `components` config in `astro.config.mjs`. The custom component lives at `src/components/Footer.astro`.

Closes #4